### PR TITLE
Caricamento dei programmi La7 senza titolo

### DIFF
--- a/resources/lib/config.json
+++ b/resources/lib/config.json
@@ -1,0 +1,9 @@
+{
+  "exclusions": ["/meteola7", "/meteo-della-sera", "/tgla7", "/film", "/film-e-fiction"],
+  "mappings": {
+    "/facciaafaccia": "/faccia-a-faccia",
+    "/il-boss-dei-comici": "/boss-dei-comici",
+    "/lariadestate": "/laria-destate",
+    "/taga-doc": "/tagada-doc"
+  }
+}

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -261,104 +261,107 @@ def programmi_lettera():
 
     if programmi or programmila7d or tutti_programmi:
         for dati in programmi:
-            if dati.find('div', class_='titolo'):
-                titolo = dati.find('div', class_='titolo').text.strip()
+            if dati.find('a') is None:
+                continue
+            url_trovato = dati.a.get('href').strip()
+            # xbmc.log('URL--------: '+str(url_trovato),xbmc.LOGINFO)
+            if url_trovato != '/meteola7' and url_trovato != '/meteo-della-sera' and url_trovato != '/tgla7' and url_trovato != '/film' and url_trovato != '/film-e-fiction':
+                if url_trovato == '/facciaafaccia':
+                    url_trovato = '/faccia-a-faccia'
+                if url_trovato == '/il-boss-dei-comici':
+                    url_trovato = '/boss-dei-comici'
+                if url_trovato == '/lariadestate':
+                    url_trovato = '/laria-destate'
+                if url_trovato == '/taga-doc':
+                    url_trovato = '/tagada-doc'
+                titolo = url_trovato.lstrip('/').replace('-', ' ').upper()
                 # xbmc.log('TITLE1-----: '+str(titolo),xbmc.LOGINFO)
                 liStyle = xbmcgui.ListItem(titolo, offscreen=True)
-                url_trovato = dati.a.get('href').strip()
-                # xbmc.log('URL--------: '+str(url_trovato),xbmc.LOGINFO)
-                if url_trovato != '/meteola7' and url_trovato != '/meteo-della-sera' and url_trovato != '/tgla7' and url_trovato != '/film' and url_trovato != '/film-e-fiction':
-                    if url_trovato == '/facciaafaccia':
-                        url_trovato = '/faccia-a-faccia'
-                    if url_trovato == '/il-boss-dei-comici':
-                        url_trovato = '/boss-dei-comici'
-                    if url_trovato == '/lariadestate':
-                        url_trovato = '/laria-destate'
-                    if url_trovato == '/taga-doc':
-                        url_trovato = '/tagada-doc'
-                    link = G.URL_BASE + url_trovato
-                    # xbmc.log('LINK-----: '+str(link),xbmc.LOGINFO)
-                    if len(dati) > 0:
-                        try:
-                            thumb = dati.find('div', class_='image-bg lozad').get('data-background-image')
-                        except Exception as e:
-                            e = sys.exc_info()[0]
-                            xbmc.log('EXCEP THUMB1: ' + str(e), xbmc.LOGINFO)
-                            thumb = ''
-                        if thumb:
-                            liStyle.setArt({'thumb': thumb})
-                        else:
-                            xbmc.log('NO THUMB1', xbmc.LOGINFO)
-                    liStyle.setArt({'fanart': G.FANART_PATH})
-                    add_directory_item_nodup({"mode": G.MODE, "link": link}, liStyle, titolo)
+                link = G.URL_BASE + url_trovato
+                # xbmc.log('LINK-----: '+str(link),xbmc.LOGINFO)
+                if len(dati) > 0:
+                    try:
+                        thumb = dati.find('div', class_='image-bg lozad').get('data-background-image')
+                    except Exception as e:
+                        e = sys.exc_info()[0]
+                        xbmc.log('EXCEP THUMB1: ' + str(e), xbmc.LOGINFO)
+                        thumb = ''
+                    if thumb:
+                        liStyle.setArt({'thumb': thumb})
+                    else:
+                        xbmc.log('NO THUMB1', xbmc.LOGINFO)
+                liStyle.setArt({'fanart': G.FANART_PATH})
+                add_directory_item_nodup({"mode": G.MODE, "link": link}, liStyle, titolo)
 
-                    if titolo not in G.LIST_PROGRAMMI:
-                        G.LIST_PROGRAMMI.append(titolo)
+                if titolo not in G.LIST_PROGRAMMI:
+                    G.LIST_PROGRAMMI.append(titolo)
 
         for dati in programmila7d:
-            if dati.find('div', class_='titolo'):
-                titolo = dati.find('div', class_='titolo').text.strip()
+            if dati.find('a') is None:
+                continue
+            url_trovato = dati.a.get('href').strip()
+            if url_trovato != '/meteola7' and url_trovato != '/meteo-della-sera' and url_trovato != '/tgla7' and url_trovato != '/film' and url_trovato != '/film-e-fiction':
+                if url_trovato == '/facciaafaccia':
+                    url_trovato = '/faccia-a-faccia'
+                if url_trovato == '/il-boss-dei-comici':
+                    url_trovato = '/boss-dei-comici'
+                if url_trovato == '/lariadestate':
+                    url_trovato = '/laria-destate'
+                if url_trovato == '/taga-doc':
+                    url_trovato = '/tagada-doc'
+                titolo = url_trovato.lstrip('/').replace('-', ' ').upper()
                 # xbmc.log('TITLE1-----: '+str(titolo),xbmc.LOGINFO)
                 liStyle = xbmcgui.ListItem(titolo, offscreen=True)
-                url_trovato = dati.a.get('href').strip()
-                if url_trovato != '/meteola7' and url_trovato != '/meteo-della-sera' and url_trovato != '/tgla7' and url_trovato != '/film' and url_trovato != '/film-e-fiction':
-                    if url_trovato == '/facciaafaccia':
-                        url_trovato = '/faccia-a-faccia'
-                    if url_trovato == '/il-boss-dei-comici':
-                        url_trovato = '/boss-dei-comici'
-                    if url_trovato == '/lariadestate':
-                        url_trovato = '/laria-destate'
-                    if url_trovato == '/taga-doc':
-                        url_trovato = '/tagada-doc'
-                    link = G.URL_BASE + url_trovato
-                    # xbmc.log('LINK-----: '+str(link),xbmc.LOGINFO)
-                    if len(dati) > 0:
-                        try:
-                            thumb = dati.find('div', class_='image-bg lozad').get('data-background-image')
-                        except Exception as e:
-                            e = sys.exc_info()[0]
-                            xbmc.log('EXCEP THUMB2: ' + str(e), xbmc.LOGINFO)
-                            thumb = ''
-                        if thumb:
-                            liStyle.setArt({'thumb': thumb})
-                        else:
-                            xbmc.log('NO THUMB2', xbmc.LOGINFO)
-                    liStyle.setArt({'fanart': G.FANART_PATH})
-                    add_directory_item_nodup({"mode": G.MODE, "link": link}, liStyle, titolo)
-                    if titolo not in G.LIST_PROGRAMMI:
-                        G.LIST_PROGRAMMI.append(titolo)
+                link = G.URL_BASE + url_trovato
+                # xbmc.log('LINK-----: '+str(link),xbmc.LOGINFO)
+                if len(dati) > 0:
+                    try:
+                        thumb = dati.find('div', class_='image-bg lozad').get('data-background-image')
+                    except Exception as e:
+                        e = sys.exc_info()[0]
+                        xbmc.log('EXCEP THUMB2: ' + str(e), xbmc.LOGINFO)
+                        thumb = ''
+                    if thumb:
+                        liStyle.setArt({'thumb': thumb})
+                    else:
+                        xbmc.log('NO THUMB2', xbmc.LOGINFO)
+                liStyle.setArt({'fanart': G.FANART_PATH})
+                add_directory_item_nodup({"mode": G.MODE, "link": link}, liStyle, titolo)
+                if titolo not in G.LIST_PROGRAMMI:
+                    G.LIST_PROGRAMMI.append(titolo)
 
         for dati in tutti_programmi:
-            if dati.find('div', class_='titolo'):
-                titolo = dati.find('div', class_='titolo').text.strip()
+            if dati.find('a') is None:
+                continue
+            url_trovato = dati.a.get('href').strip()
+            # xbmc.log('URL TROVATO-----: '+str(url_trovato),xbmc.LOGINFO)
+            if url_trovato != '/meteola7' and url_trovato != '/meteo-della-sera' and url_trovato != '/tgla7' and url_trovato != '/film' and url_trovato != '/film-e-fiction':
+                if url_trovato == '/facciaafaccia':
+                    url_trovato = '/faccia-a-faccia'
+                if url_trovato == '/il-boss-dei-comici':
+                    url_trovato = '/boss-dei-comici'
+                if url_trovato == '/lariadestate':
+                    url_trovato = '/laria-destate'
+                if url_trovato == '/taga-doc':
+                    url_trovato = '/tagada-doc'
+                titolo = url_trovato.lstrip('/').replace('-', ' ').upper()
                 # xbmc.log('TITLE2: '+str(titolo),xbmc.LOGINFO)
                 liStyle = xbmcgui.ListItem(titolo, offscreen=True)
-                url_trovato = dati.a.get('href').strip()
-                # xbmc.log('URL TROVATO-----: '+str(url_trovato),xbmc.LOGINFO)
-                if url_trovato != '/meteola7' and url_trovato != '/meteo-della-sera' and url_trovato != '/tgla7' and url_trovato != '/film' and url_trovato != '/film-e-fiction':
-                    if url_trovato == '/facciaafaccia':
-                        url_trovato = '/faccia-a-faccia'
-                    if url_trovato == '/il-boss-dei-comici':
-                        url_trovato = '/boss-dei-comici'
-                    if url_trovato == '/lariadestate':
-                        url_trovato = '/laria-destate'
-                    if url_trovato == '/taga-doc':
-                        url_trovato = '/tagada-doc'
-                    link = G.URL_BASE + url_trovato
-                    # xbmc.log('LINK-----: '+str(link),xbmc.LOGINFO)
-                    if len(dati) > 0:
-                        try:
-                            thumb = dati.find('div', class_='image-bg lozad').get('data-background-image')
-                        except Exception as e:
-                            e = sys.exc_info()[0]
-                            xbmc.log('EXCEP THUMB3: ' + str(e), xbmc.LOGINFO)
-                            thumb = ''
-                        if thumb:
-                            liStyle.setArt({'thumb': thumb})
-                        else:
-                            xbmc.log('NO THUMB3', xbmc.LOGINFO)
-                    liStyle.setArt({'fanart': G.FANART_PATH})
-                    add_directory_item_nodup({"mode": G.MODE, "link": link}, liStyle, titolo)
+                link = G.URL_BASE + url_trovato
+                # xbmc.log('LINK-----: '+str(link),xbmc.LOGINFO)
+                if len(dati) > 0:
+                    try:
+                        thumb = dati.find('div', class_='image-bg lozad').get('data-background-image')
+                    except Exception as e:
+                        e = sys.exc_info()[0]
+                        xbmc.log('EXCEP THUMB3: ' + str(e), xbmc.LOGINFO)
+                        thumb = ''
+                    if thumb:
+                        liStyle.setArt({'thumb': thumb})
+                    else:
+                        xbmc.log('NO THUMB3', xbmc.LOGINFO)
+                liStyle.setArt({'fanart': G.FANART_PATH})
+                add_directory_item_nodup({"mode": G.MODE, "link": link}, liStyle, titolo)
 
         # Prog aggiunti manualmente
         programmi = {
@@ -420,6 +423,8 @@ def programmi_lettera_teche_la7():
 
     if teche_la7:
         for dati in teche_la7:
+            if dati.find('a') is None:
+                continue
             if dati.find('div', class_='titolo'):
                 nomicognomi = dati.find('div', class_='titolo').text.strip()
                 cognominomi = " ".join(reversed(nomicognomi.split(" ")))

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -251,7 +251,11 @@ def process_program_data(dati, config):
     # xbmc.log('URL--------: '+str(url_trovato),xbmc.LOGINFO)
     if url_trovato not in config['exclusions']:
         url_trovato = config['mappings'].get(url_trovato, url_trovato)
-        titolo = url_trovato.lstrip('/').replace('-', ' ').upper()
+        titolo = ''
+        if dati.find('div', class_='titolo'):
+            titolo = dati.find('div', class_='titolo').text.strip()
+        if titolo == '':
+            titolo = url_trovato.lstrip('/').replace('-', ' ').upper()
         # xbmc.log('TITLE1-----: '+str(titolo),xbmc.LOGINFO)
         liStyle = xbmcgui.ListItem(titolo, offscreen=True)
         link = G.URL_BASE + url_trovato

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -1,3 +1,4 @@
+import json
 import re
 import os
 import sys
@@ -243,6 +244,34 @@ def rivedi_giorno():
     xbmcplugin.setContent(G.PLUGIN_HANDLE, 'episodes')
     xbmcplugin.endOfDirectory(handle=G.PLUGIN_HANDLE, succeeded=True)
 
+def process_program_data(dati, config):
+    if dati.find('a') is None:
+        return
+    url_trovato = dati.a.get('href').strip()
+    # xbmc.log('URL--------: '+str(url_trovato),xbmc.LOGINFO)
+    if url_trovato not in config['exclusions']:
+        url_trovato = config['mappings'].get(url_trovato, url_trovato)
+        titolo = url_trovato.lstrip('/').replace('-', ' ').upper()
+        # xbmc.log('TITLE1-----: '+str(titolo),xbmc.LOGINFO)
+        liStyle = xbmcgui.ListItem(titolo, offscreen=True)
+        link = G.URL_BASE + url_trovato
+        # xbmc.log('LINK-----: '+str(link),xbmc.LOGINFO)
+        if len(dati) > 0:
+            try:
+                thumb = dati.find('div', class_='image-bg lozad').get('data-background-image')
+            except Exception as e:
+                e = sys.exc_info()[0]
+                xbmc.log('EXCEP THUMB1: ' + str(e), xbmc.LOGINFO)
+                thumb = ''
+            if thumb:
+                liStyle.setArt({'thumb': thumb})
+            else:
+                xbmc.log('NO THUMB1', xbmc.LOGINFO)
+        liStyle.setArt({'fanart': G.FANART_PATH})
+        add_directory_item_nodup({"mode": G.MODE, "link": link}, liStyle, titolo)
+
+        if titolo not in G.LIST_PROGRAMMI:
+            G.LIST_PROGRAMMI.append(titolo)
 
 def programmi_lettera():
     req_p = Request(G.URL_PROGRAMMI, headers={'user-agent': G.HEADERS_SET['user-agent']})
@@ -259,109 +288,19 @@ def programmi_lettera():
     html_tp = BeautifulSoup(page_tp, 'html.parser')
     tutti_programmi = html_tp.find_all('div', class_='list-item')
 
+    config_path = os.path.join(os.path.dirname(__file__), 'config.json')
+    with open(config_path, 'r') as config_file:
+        config = json.load(config_file)
+        
     if programmi or programmila7d or tutti_programmi:
         for dati in programmi:
-            if dati.find('a') is None:
-                continue
-            url_trovato = dati.a.get('href').strip()
-            # xbmc.log('URL--------: '+str(url_trovato),xbmc.LOGINFO)
-            if url_trovato != '/meteola7' and url_trovato != '/meteo-della-sera' and url_trovato != '/tgla7' and url_trovato != '/film' and url_trovato != '/film-e-fiction':
-                if url_trovato == '/facciaafaccia':
-                    url_trovato = '/faccia-a-faccia'
-                if url_trovato == '/il-boss-dei-comici':
-                    url_trovato = '/boss-dei-comici'
-                if url_trovato == '/lariadestate':
-                    url_trovato = '/laria-destate'
-                if url_trovato == '/taga-doc':
-                    url_trovato = '/tagada-doc'
-                titolo = url_trovato.lstrip('/').replace('-', ' ').upper()
-                # xbmc.log('TITLE1-----: '+str(titolo),xbmc.LOGINFO)
-                liStyle = xbmcgui.ListItem(titolo, offscreen=True)
-                link = G.URL_BASE + url_trovato
-                # xbmc.log('LINK-----: '+str(link),xbmc.LOGINFO)
-                if len(dati) > 0:
-                    try:
-                        thumb = dati.find('div', class_='image-bg lozad').get('data-background-image')
-                    except Exception as e:
-                        e = sys.exc_info()[0]
-                        xbmc.log('EXCEP THUMB1: ' + str(e), xbmc.LOGINFO)
-                        thumb = ''
-                    if thumb:
-                        liStyle.setArt({'thumb': thumb})
-                    else:
-                        xbmc.log('NO THUMB1', xbmc.LOGINFO)
-                liStyle.setArt({'fanart': G.FANART_PATH})
-                add_directory_item_nodup({"mode": G.MODE, "link": link}, liStyle, titolo)
-
-                if titolo not in G.LIST_PROGRAMMI:
-                    G.LIST_PROGRAMMI.append(titolo)
+            process_program_data(dati, config)
 
         for dati in programmila7d:
-            if dati.find('a') is None:
-                continue
-            url_trovato = dati.a.get('href').strip()
-            if url_trovato != '/meteola7' and url_trovato != '/meteo-della-sera' and url_trovato != '/tgla7' and url_trovato != '/film' and url_trovato != '/film-e-fiction':
-                if url_trovato == '/facciaafaccia':
-                    url_trovato = '/faccia-a-faccia'
-                if url_trovato == '/il-boss-dei-comici':
-                    url_trovato = '/boss-dei-comici'
-                if url_trovato == '/lariadestate':
-                    url_trovato = '/laria-destate'
-                if url_trovato == '/taga-doc':
-                    url_trovato = '/tagada-doc'
-                titolo = url_trovato.lstrip('/').replace('-', ' ').upper()
-                # xbmc.log('TITLE1-----: '+str(titolo),xbmc.LOGINFO)
-                liStyle = xbmcgui.ListItem(titolo, offscreen=True)
-                link = G.URL_BASE + url_trovato
-                # xbmc.log('LINK-----: '+str(link),xbmc.LOGINFO)
-                if len(dati) > 0:
-                    try:
-                        thumb = dati.find('div', class_='image-bg lozad').get('data-background-image')
-                    except Exception as e:
-                        e = sys.exc_info()[0]
-                        xbmc.log('EXCEP THUMB2: ' + str(e), xbmc.LOGINFO)
-                        thumb = ''
-                    if thumb:
-                        liStyle.setArt({'thumb': thumb})
-                    else:
-                        xbmc.log('NO THUMB2', xbmc.LOGINFO)
-                liStyle.setArt({'fanart': G.FANART_PATH})
-                add_directory_item_nodup({"mode": G.MODE, "link": link}, liStyle, titolo)
-                if titolo not in G.LIST_PROGRAMMI:
-                    G.LIST_PROGRAMMI.append(titolo)
-
+            process_program_data(dati, config)
+            
         for dati in tutti_programmi:
-            if dati.find('a') is None:
-                continue
-            url_trovato = dati.a.get('href').strip()
-            # xbmc.log('URL TROVATO-----: '+str(url_trovato),xbmc.LOGINFO)
-            if url_trovato != '/meteola7' and url_trovato != '/meteo-della-sera' and url_trovato != '/tgla7' and url_trovato != '/film' and url_trovato != '/film-e-fiction':
-                if url_trovato == '/facciaafaccia':
-                    url_trovato = '/faccia-a-faccia'
-                if url_trovato == '/il-boss-dei-comici':
-                    url_trovato = '/boss-dei-comici'
-                if url_trovato == '/lariadestate':
-                    url_trovato = '/laria-destate'
-                if url_trovato == '/taga-doc':
-                    url_trovato = '/tagada-doc'
-                titolo = url_trovato.lstrip('/').replace('-', ' ').upper()
-                # xbmc.log('TITLE2: '+str(titolo),xbmc.LOGINFO)
-                liStyle = xbmcgui.ListItem(titolo, offscreen=True)
-                link = G.URL_BASE + url_trovato
-                # xbmc.log('LINK-----: '+str(link),xbmc.LOGINFO)
-                if len(dati) > 0:
-                    try:
-                        thumb = dati.find('div', class_='image-bg lozad').get('data-background-image')
-                    except Exception as e:
-                        e = sys.exc_info()[0]
-                        xbmc.log('EXCEP THUMB3: ' + str(e), xbmc.LOGINFO)
-                        thumb = ''
-                    if thumb:
-                        liStyle.setArt({'thumb': thumb})
-                    else:
-                        xbmc.log('NO THUMB3', xbmc.LOGINFO)
-                liStyle.setArt({'fanart': G.FANART_PATH})
-                add_directory_item_nodup({"mode": G.MODE, "link": link}, liStyle, titolo)
+            process_program_data(dati, config)
 
         # Prog aggiunti manualmente
         programmi = {


### PR DESCRIPTION
Risolve #78 

Sembra che il titolo sia ora vuoto: il codice di processamento dei titoli è stato spostato in un'unica funzione e in caso di titolo vuoto, appunto, usa il path stesso per desumerlo.